### PR TITLE
Feature/convert-to-pylint-plugin

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,6 +78,10 @@ exclude = [
 warn_unused_ignores = true
 warn_redundant_casts = true
 
+[[tool.mypy.overrides]]
+module = "astroid.*"
+ignore_missing_imports = true
+
 [tool.uv]
 dev-dependencies = [
     "pytest>=7.0.0",

--- a/src/importlinter/application/formatters.py
+++ b/src/importlinter/application/formatters.py
@@ -6,6 +6,7 @@ with CI/CD systems and automated tooling.
 """
 
 import json
+from typing import Any
 
 from importlinter.application.constants import (
     get_message_id_for_contract_type,
@@ -13,14 +14,14 @@ from importlinter.application.constants import (
 )
 
 
-def format_report_as_json(report, folder_info: str = "") -> str:
+def format_report_as_json(report: Any, folder_info: str = "") -> str:
     """
     Format an import-linter report as JSON output.
 
     This provides structured output compatible with the pylint plugin format
     for consistent tooling integration.
     """
-    result = {
+    result: dict[str, Any] = {
         "summary": {
             "analyzed_files": getattr(report, "number_of_modules", 0),
             "dependencies": getattr(report, "number_of_dependencies", 0),
@@ -78,15 +79,15 @@ def format_report_as_json(report, folder_info: str = "") -> str:
     return json.dumps(result, indent=2)
 
 
-def format_report_as_json2(report, folder_info: str = "") -> str:
+def format_report_as_json2(report: Any, folder_info: str = "") -> str:
     """
     Format an import-linter report as JSON2 output (improved format with statistics).
 
     This provides structured output compatible with pylint's json2 format,
     including statistics and enhanced message structure.
     """
-    messages = []
-    statistics = {
+    messages: list[dict[str, Any]] = []
+    statistics: dict[str, Any] = {
         "messageTypeCount": {
             "fatal": 0,
             "error": 0,

--- a/src/importlinter/application/ports/reporting.py
+++ b/src/importlinter/application/ports/reporting.py
@@ -5,11 +5,19 @@ from grimp import ImportGraph
 
 
 class Reporter:
-    ...
+    """Base class for reporting contract violations."""
+
+    def report(self, report):
+        """Report contract violations."""
+        raise NotImplementedError
 
 
 class ExceptionReporter:
-    ...
+    """Base class for reporting exceptions during contract checking."""
+
+    def report_exception(self, exception):
+        """Report an exception that occurred during contract checking."""
+        raise NotImplementedError
 
 
 class Report:

--- a/src/importlinter/pylint_plugin.py
+++ b/src/importlinter/pylint_plugin.py
@@ -8,10 +8,16 @@ from __future__ import annotations
 
 import os
 import sys
-from typing import TYPE_CHECKING, Union, Any
+from typing import Union, Any
 
 from pylint import checkers
 from pylint.lint import PyLinter
+
+# Import astroid outside TYPE_CHECKING to avoid mypy version conflicts
+try:
+    from astroid import nodes
+except ImportError:
+    nodes = None
 
 from importlinter.application.sentinels import NotSupplied
 from importlinter.configuration import configure
@@ -23,9 +29,6 @@ from importlinter.application.constants import (
     format_violation_message,
     get_message_id_for_contract_type,
 )
-
-if TYPE_CHECKING:
-    from astroid import nodes  # type: ignore[import-untyped]
 
 # Configure import-linter
 configure()

--- a/src/importlinter/pylint_plugin.py
+++ b/src/importlinter/pylint_plugin.py
@@ -25,7 +25,7 @@ from importlinter.application.constants import (
 )
 
 if TYPE_CHECKING:
-    from astroid import nodes
+    from astroid import nodes  # type: ignore[import-untyped]
 
 # Configure import-linter
 configure()


### PR DESCRIPTION
- Add proper type annotations to formatters.py to fix Collection[str] errors
- Fix astroid import type annotation in pylint_plugin.py
- Replace ellipsis-based class definitions with proper implementations
- All quality checks now pass: black, flake8, mypy